### PR TITLE
DA-102: Updated main pipeline page and added monaco editor

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
         "@fortawesome/free-regular-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.16",
+        "@monaco-editor/react": "^4.3.1",
         "@mui/material": "^5.2.3",
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^11.1.0",

--- a/frontend/src/components/DrawerContent/ShowYAMLCodeDrawer/index.jsx
+++ b/frontend/src/components/DrawerContent/ShowYAMLCodeDrawer/index.jsx
@@ -1,0 +1,142 @@
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Box, Button, ButtonGroup, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import Editor, { useMonaco } from '@monaco-editor/react';
+import { useTheme } from '@emotion/react';
+
+const ShowYAMLCodeDrawer = ({ handleClose }) => {
+    // States
+    const [fileName, setFileName] = useState('YAML');
+
+    // Theme hook
+    const theme = useTheme();
+
+    // Editor configs
+    const monaco = useMonaco();
+    const file = files[fileName];
+
+    useEffect(() => {
+        if (monaco) {
+            monaco.editor.defineTheme('customTheme', {
+                base: 'vs',
+                inherit: true,
+                rules: [],
+                colors: {
+                    'editor.foreground': '#000000',
+                    'editor.background': '#fff',
+                    'editor.lineHighlightBackground': '#F2F2F2',
+                    'editorLineNumber.foreground': '#222',
+                    'editor.selectionBackground': '#EDEDED',
+                    'editorGutter.background': '#F2F2F2',
+                },
+            });
+        }
+    }, [monaco]);
+
+    return (
+        <Box position="relative">
+            <Box sx={{ p: '4.125rem 2.5rem', pb: 0 }} display="flex" alignItems="center" justifyContent="space-between">
+                <Typography component="h2" variant="h3">
+                    Code
+                </Typography>
+                <Button variant="text" onClick={handleClose} style={{ paddingLeft: '16px', paddingRight: '16px' }} startIcon={<FontAwesomeIcon icon={faTimes} />}>
+                    Close
+                </Button>
+            </Box>
+
+            <Box mt={2} p="0 2.5rem">
+                <ButtonGroup variant="text" aria-label="text button group">
+                    <Button
+                        onClick={() => setFileName('YAML')}
+                        sx={{
+                            background: (theme) => (fileName === 'YAML' ? theme.palette.editor.selectedTabColor : theme.palette.editor.tabColor),
+                            color: (theme) => theme.palette.editor.tabTextColor,
+                            padding: '7px 11px',
+                        }}>
+                        YAML
+                    </Button>
+                    <Button
+                        onClick={() => setFileName('JSON')}
+                        sx={{
+                            background: (theme) => (fileName === 'JSON' ? theme.palette.editor.selectedTabColor : theme.palette.editor.tabColor),
+                            color: (theme) => theme.palette.editor.tabTextColor,
+                            padding: '0 11px',
+                        }}>
+                        JSON
+                    </Button>
+                </ButtonGroup>
+                <Editor
+                    theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'customTheme'}
+                    height="357px"
+                    path={file.name}
+                    defaultLanguage={file.language}
+                    defaultValue={file.value}
+                />
+            </Box>
+        </Box>
+    );
+};
+
+const YAML_CODE_EXAMPLE = `%TAG ! tag:clarkevans.com,2002:
+--- !shape
+  # Use the ! handle for presenting
+  # tag:clarkevans.com,2002:circle
+- !circle
+  center: &ORIGIN {x: 73, y: 129}
+  radius: 7
+- !line
+  start: *ORIGIN
+  finish: { x: 89, y: 102 }
+- !label
+  start: *ORIGIN
+  color: 0xFFEEBB
+  text: Pretty vector drawing.
+`;
+
+const files = {
+    YAML: {
+        name: 'YAML',
+        language: 'yaml',
+        value: YAML_CODE_EXAMPLE,
+    },
+    JSON: {
+        name: 'JSON',
+        language: 'json',
+        value: formatJSON(`{
+            "port": 8080,
+            "exclude_from_auth": [
+              "/login",
+              "/check_token",
+              "/battles:get",
+              "/team"
+            ],
+            "db": {
+              "default_data": {
+                "battles": [],
+                "active_battle_id": null,
+                "admin": {},
+                "secret": "",
+                "active_tokens": []
+              },
+              "path": ".db.json"
+            }
+        }
+      `),
+    },
+};
+
+// This function will format the JSON code
+export function formatJSON(val = {}) {
+    try {
+        const res = JSON.parse(val);
+        return JSON.stringify(res, null, 2);
+    } catch {
+        const errorJson = {
+            error: `Something went wrong${val}`,
+        };
+        return JSON.stringify(errorJson, null, 2);
+    }
+}
+
+export default ShowYAMLCodeDrawer;

--- a/frontend/src/components/MoreInfoContent/PipelinePageItem/index.jsx
+++ b/frontend/src/components/MoreInfoContent/PipelinePageItem/index.jsx
@@ -1,0 +1,16 @@
+import { MenuItem } from '@mui/material';
+
+const PipelinePageItem = (props) => {
+    const refreshClick = () => {
+        props.handleCloseMenu();
+        props.handleRefresh();
+    };
+
+    return (
+        <MenuItem sx={{ color: 'cyan.main' }} onClick={refreshClick}>
+            Refresh all
+        </MenuItem>
+    );
+};
+
+export default PipelinePageItem;

--- a/frontend/src/components/MoreInfoContent/PipelineTableItem/index.jsx
+++ b/frontend/src/components/MoreInfoContent/PipelineTableItem/index.jsx
@@ -1,0 +1,33 @@
+import { MenuItem } from '@mui/material';
+
+const PipelineItemTable = (props) => {
+    const yamlClick = () => {
+        props.handleCloseMenu();
+        props.handleOpenYaml();
+    };
+
+    return (
+        <>
+            <MenuItem sx={{ color: 'cyan.main' }} onClick={yamlClick}>
+                View YAML
+            </MenuItem>
+            <MenuItem sx={{ color: 'cyan.main' }} onClick={() => props.handleCloseMenu()}>
+                Turn off
+            </MenuItem>
+            <MenuItem sx={{ color: 'cyan.main' }} onClick={() => props.handleCloseMenu()}>
+                Permissions
+            </MenuItem>
+            <MenuItem sx={{ color: 'cyan.main' }} onClick={() => props.handleCloseMenu()}>
+                Reload
+            </MenuItem>
+            <MenuItem sx={{ color: 'cyan.main' }} onClick={() => props.handleCloseMenu()}>
+                Deploy
+            </MenuItem>
+            <MenuItem sx={{ color: 'error.main' }} onClick={() => props.handleCloseMenu()}>
+                Delete
+            </MenuItem>
+        </>
+    );
+};
+
+export default PipelineItemTable;

--- a/frontend/src/components/MoreInfoMenu/index.jsx
+++ b/frontend/src/components/MoreInfoMenu/index.jsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
+import { Box } from '@mui/material';
+import { useTheme } from '@emotion/react';
+
+const ITEM_HEIGHT = 48;
+
+const MoreInfoMenu = ({ children, iconSize = 22, ...props }) => {
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const open = Boolean(anchorEl);
+    const handleClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const theme = useTheme();
+
+    return (
+        <div>
+            <IconButton
+                aria-label="more"
+                id="long-button"
+                aria-controls={open ? 'long-menu' : undefined}
+                aria-expanded={open ? 'true' : undefined}
+                aria-haspopup="true"
+                onClick={handleClick}>
+                <Box component={FontAwesomeIcon} fontSize={iconSize} icon={faEllipsisV} />
+            </IconButton>
+            <Menu
+                {...props}
+                id="long-menu"
+                MenuListProps={{
+                    'aria-labelledby': 'long-button',
+                }}
+                anchorEl={anchorEl}
+                open={open}
+                sx={{}}
+                onClose={handleClose}
+                PaperProps={{
+                    style: {
+                        border: theme.palette.mode === 'dark' ? '' : '1px solid #C4C4C4',
+                        maxHeight: ITEM_HEIGHT * 5,
+                        width: '20ch',
+                    },
+                }}>
+                {React.Children.map(children, (child) => {
+                    return React.cloneElement(child, { handleCloseMenu: handleClose });
+                })}
+            </Menu>
+        </div>
+    );
+};
+
+export default MoreInfoMenu;

--- a/frontend/src/components/TableContent/PipelineTable/index.jsx
+++ b/frontend/src/components/TableContent/PipelineTable/index.jsx
@@ -1,23 +1,34 @@
-import { Box, Typography, Grid, IconButton, Avatar } from '@mui/material';
-import { useMemo } from 'react';
+import { Box, Typography, Grid, Drawer, Avatar, AvatarGroup } from '@mui/material';
+import { useMemo, useState } from 'react';
 import { useTable, useGlobalFilter } from 'react-table';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEllipsisV, faRedo } from '@fortawesome/free-solid-svg-icons';
 import { faPlayCircle, faClock } from '@fortawesome/free-regular-svg-icons';
 import CustomChip from '../../CustomChip';
+import MoreInfoMenu from '../../MoreInfoMenu';
+import PipelineItemTable from '../../MoreInfoContent/PipelineTableItem';
+import customDrawerStyles from '../../../utils/drawerStyles';
+import ShowYAMLCodeDrawer from '../../DrawerContent/ShowYAMLCodeDrawer';
 
 const PipelineTable = () => {
+    // Table item states
+    const [isOpenYAML, setIsOpenYAML] = useState(false);
+
     const columns = useMemo(
         () => [
             {
                 Header: 'Trigger',
                 accessor: 'trigger',
                 Cell: (row) => (
-                    <Grid container alignItems="center" justifyContent="center" flexWrap="nowrap">
-                        <Box component={FontAwesomeIcon} fontSize={15} color="error.main" icon={faClock} />
-                        <Typography fontSize={15} ml={0.7} fontWeight={500} lineHeight="16.94px">
-                            {row.value}
-                        </Typography>
+                    <Grid container alignItems="flex-start" flexWrap="nowrap">
+                        <Box component={FontAwesomeIcon} fontSize={19} color="error.main" icon={faClock} />
+                        <Box ml={0.7}>
+                            <Typography fontSize={15} fontWeight={500} lineHeight="16.94px">
+                                {row.value}
+                            </Typography>
+                            <Typography fontSize={15} fontWeight={500} mt={0.5} lineHeight="16.94px">
+                                */5****
+                            </Typography>
+                        </Box>
                     </Grid>
                 ),
             },
@@ -25,7 +36,7 @@ const PipelineTable = () => {
                 Header: 'Next run',
                 accessor: 'next_run',
                 Cell: (row) => (
-                    <Grid container alignItems="flex-start" flexDirection="column" justifyContent="center" mr={2} ml={2}>
+                    <Grid container alignItems="flex-start" flexDirection="column" justifyContent="center">
                         <Typography fontSize={15} fontWeight={500}>
                             {row.value}
                         </Typography>
@@ -53,41 +64,24 @@ const PipelineTable = () => {
                 Header: 'Runs',
                 accessor: 'runs',
                 Cell: (row) => (
-                    <Grid container alignItems="center" justifyContent="center">
-                        <Avatar sx={{ backgroundColor: 'secondary.light', color: 'secondary.main', mr: 1, width: 24, height: 24, fontSize: 14, fontWeight: 700 }}>10</Avatar>
-                        <Avatar sx={{ backgroundColor: 'success.light', color: 'success.main', width: 24, height: 24, fontSize: 14, fontWeight: 700 }}>10</Avatar>
+                    <Grid container alignItems="center" justifyContent="flex-start" ml={-0.5}>
+                        <AvatarGroup max={4}>
+                            <Avatar sx={{ backgroundColor: 'secondary.light', color: 'secondary.main', mr: 1, width: 24, height: 24, fontSize: 14, fontWeight: 700 }}>10</Avatar>
+                            <Avatar sx={{ backgroundColor: 'success.light', color: 'success.main', width: 24, height: 24, fontSize: 14, fontWeight: 700 }}>10</Avatar>
+                        </AvatarGroup>
                     </Grid>
                 ),
             },
             {
-                Header: 'Actions',
-                accessor: 'actions',
-                Cell: (row) => (
-                    <Grid container alignItems="center" justifyContent="center">
-                        <Box component={FontAwesomeIcon} fontSize={26} color="cyan.main" mr={0.8} icon={faPlayCircle} />
-                        <Box component={FontAwesomeIcon} fontSize={24} color="cyan.main" icon={faRedo} />
-                    </Grid>
-                ),
-            },
-            {
-                Header: 'Status',
                 accessor: 'status',
-                Cell: (row) => (
-                    <Grid container alignItems="center" justifyContent="center">
-                        <CustomChip amount={10} label="Running" customColor="green" />
-                    </Grid>
-                ),
-            },
-            {
-                Header: 'Manage',
-                accessor: 'manage',
-                Cell: (row) => (
-                    <Grid container alignItems="center" justifyContent="center">
-                        <IconButton>
-                            <Box component={FontAwesomeIcon} fontSize={20} icon={faEllipsisV} />
-                        </IconButton>
-                    </Grid>
-                ),
+                Cell: (row) => {
+                    console.log(row);
+                    return (
+                        <Grid container alignItems="center">
+                            <CustomChip amount={row.value?.amount} label={row.value?.text} customColor="green" />
+                        </Grid>
+                    );
+                },
             },
         ],
         []
@@ -103,67 +97,105 @@ const PipelineTable = () => {
     );
 
     return (
-        <Box component="table" mt={4} width="100%" {...getTableProps()}>
-            <thead>
-                {headerGroups.map((headerGroup) => (
-                    <Box
-                        component="tr"
-                        display="grid"
-                        gridTemplateColumns="repeat(7, 1fr)"
-                        justifyContent="center"
-                        sx={{ padding: '0 24px 0 0' }}
-                        {...headerGroup.getHeaderGroupProps()}>
-                        {headerGroup.headers.map((column) => (
-                            <Box component="td" color="text.primary" fontWeight="600" fontSize="15px" textAlign="center" {...column.getHeaderProps()}>
-                                {column.render('Header')}
-                            </Box>
-                        ))}
-                    </Box>
-                ))}
-            </thead>
-            <Box component="tbody" display="flex" sx={{ flexDirection: 'column' }} {...getTableBodyProps()}>
-                {rows.map((row, i) => {
-                    prepareRow(row);
-                    return (
-                        <Box
-                            component="tr"
-                            {...row.getRowProps()}
-                            display="flex"
-                            flexDirection="column"
-                            borderRadius="5px"
-                            backgroundColor="background.secondary"
-                            sx={{ border: 1, borderColor: 'divider', padding: 3, cursor: 'pointer', '&:hover': { background: 'background.hoverSecondary' }, mt: 2 }}>
-                            <Grid display="flex" alignItems="center" justifyContent="space-between">
-                                <Grid item>
-                                    <Typography variant="h3" color="cyan.main">
-                                        Remove logs
-                                    </Typography>
-                                    <Typography fontSize={15} color="text.primary" mt={0.3}>
-                                        This removes the logs that build up.{' '}
-                                    </Typography>
-                                </Grid>
+        <>
+            <Box component="table" mt={4} width="100%" {...getTableProps()}>
+                <Box component="tbody" display="flex" sx={{ flexDirection: 'column' }} {...getTableBodyProps()}>
+                    {rows.map((row, i) => {
+                        prepareRow(row);
+                        return (
+                            <Box
+                                component="tr"
+                                {...row.getRowProps()}
+                                display="flex"
+                                flexDirection="column"
+                                borderRadius="5px"
+                                backgroundColor="background.secondary"
+                                sx={{ border: 1, borderColor: 'divider', padding: 3, cursor: 'pointer', '&:hover': { background: 'background.hoverSecondary' }, mt: 2 }}>
+                                <Box component="td">
+                                    <Grid display="flex" alignItems="flex-start" justifyContent="space-between">
+                                        <Grid item>
+                                            <Typography variant="h3" color="cyan.main">
+                                                Remove logs
+                                            </Typography>
+                                            <Typography fontSize={15} color="text.primary" mt={0.3}>
+                                                This removes the logs that build up.
+                                            </Typography>
+                                        </Grid>
 
-                                <Grid display="flex" alignItems="center" pr={2}>
-                                    <Box height={16} width={16} backgroundColor="rgba(114, 184, 66, 1)" borderRadius="100%"></Box>
-                                    <Typography ml={1} fontSize={14}>
-                                        Online
-                                    </Typography>
-                                </Grid>
-                            </Grid>
-                            <Box display="grid" gridTemplateColumns="repeat(7, 1fr)" alignItems="center" mt={2}>
-                                {row.cells.map((cell) => {
-                                    return (
-                                        <Box component="td" {...cell.getCellProps()} textAlign="center">
-                                            {cell.render('Cell')}
+                                        <Grid display="flex" alignItems="center">
+                                            <Box display="flex" alignItems="center" pr={2}>
+                                                <Box component={FontAwesomeIcon} fontSize={30} sx={{ color: 'cyan.main' }} icon={faPlayCircle} mr={1.5} />
+                                                <Typography variant="h3">Version {row.original.version} </Typography>
+                                            </Box>
+
+                                            <Box display="flex" alignItems="center" pr={2} ml={1.2}>
+                                                <Box
+                                                    height={16}
+                                                    width={16}
+                                                    backgroundColor={`${row.original.active ? 'status.pipelineOnline' : 'error.main'}`}
+                                                    borderRadius="100%"></Box>
+                                                <Typography ml={1} fontSize={16} sx={{ color: row.original.active ? 'status.pipelineOnlineText' : 'error.main' }}>
+                                                    {row.original.active ? 'Online' : 'Offline'}
+                                                </Typography>
+                                            </Box>
+                                        </Grid>
+                                    </Grid>
+
+                                    <Grid container alignItems="center" wrap="nowrap">
+                                        <Box mt={3} sx={{ flex: 8 }}>
+                                            {headerGroups.map((headerGroup) => (
+                                                <Box
+                                                    component="tr"
+                                                    display="grid"
+                                                    justifyContent="flex-start"
+                                                    sx={{
+                                                        padding: '0 9px 0 0',
+                                                        gridTemplateColumns: {
+                                                            xxs: '2fr 1.5fr 1.8fr 1fr 1fr',
+                                                            lg: '2fr 1.5fr 1.8fr 1fr 1fr 2fr',
+                                                        },
+                                                    }}
+                                                    {...headerGroup.getHeaderGroupProps()}>
+                                                    {headerGroup.headers.map((column) => (
+                                                        <Box component="td" color="text.primary" fontSize="17px" fontWeight="900" {...column.getHeaderProps()}>
+                                                            {column.render('Header')}
+                                                        </Box>
+                                                    ))}
+                                                </Box>
+                                            ))}
+                                            <Box
+                                                display="grid"
+                                                alignItems="flex-start"
+                                                mt={1.3}
+                                                sx={{
+                                                    gridTemplateColumns: {
+                                                        xxs: '2fr 1.5fr 1.8fr 1fr 1fr',
+                                                        lg: '2fr 1.5fr 1.8fr 1fr 1fr 2fr',
+                                                    },
+                                                }}>
+                                                {row.cells.map((cell) => {
+                                                    return <Box {...cell.getCellProps()}>{cell.render('Cell')}</Box>;
+                                                })}
+                                            </Box>
                                         </Box>
-                                    );
-                                })}
+
+                                        <Grid item sx={{ flex: 1 }} display="flex" alignItems="center" justifyContent="center">
+                                            <MoreInfoMenu>
+                                                <PipelineItemTable handleOpenYaml={() => setIsOpenYAML(!isOpenYAML)} />
+                                            </MoreInfoMenu>
+                                        </Grid>
+                                    </Grid>
+                                </Box>
                             </Box>
-                        </Box>
-                    );
-                })}
+                        );
+                    })}
+                </Box>
             </Box>
-        </Box>
+
+            <Drawer anchor="right" open={isOpenYAML} sx={customDrawerStyles} onClose={() => setIsOpenYAML(!isOpenYAML)}>
+                <ShowYAMLCodeDrawer handleClose={() => setIsOpenYAML(false)} />
+            </Drawer>
+        </>
     );
 };
 
@@ -171,22 +203,29 @@ const data = [
     {
         id: 1,
         trigger: 'Every 5 minutes',
+        version: '0.0.1',
         next_run: '27 Nov 2021',
         last_run: '27 Nov 2021',
         runs: [10, 10],
         actions: '',
-        status: '',
-        manage: '',
+        status: {
+            text: 'Running',
+            amount: 10,
+        },
+        active: true,
     },
     {
         id: 2,
         trigger: 'Every 5 minutes',
+        version: '0.0.1',
         next_run: '27 Nov 2021',
         last_run: '27 Nov 2021',
-        runs: [10, 10],
+        runs: [10, 10, 20, 30, 50],
         actions: '',
-        status: '',
-        manage: '',
+        status: {
+            text: 'Ready',
+        },
+        active: false,
     },
 ];
 

--- a/frontend/src/pages/Pipelines.jsx
+++ b/frontend/src/pages/Pipelines.jsx
@@ -1,9 +1,9 @@
 import { Box, Grid, Typography, TextField, MenuItem } from '@mui/material';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 import Search from '../components/Search';
 import CustomChip from '../components/CustomChip';
 import PipelineTable from '../components/TableContent/PipelineTable';
+import MoreInfoMenu from '../components/MoreInfoMenu';
+import PipelinePageItem from '../components/MoreInfoContent/PipelinePageItem';
 
 const Pipelines = () => {
     return (
@@ -12,7 +12,9 @@ const Pipelines = () => {
                 <Typography component="h2" variant="h2" color="text.primary">
                     Pipelines
                 </Typography>
-                <FontAwesomeIcon icon={faEllipsisV} />
+                <MoreInfoMenu>
+                    <PipelinePageItem handleRefresh={() => {}} />
+                </MoreInfoMenu>
             </Grid>
 
             <Grid container mt={4} direction="row" alignItems="center" justifyContent="flex-start" sx={{ width: { xl: '85%' } }}>

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -41,6 +41,15 @@ const createCustomTheme = (mode) => ({
                   cyan: {
                       main: '#0073C6',
                   },
+                  editor: {
+                      selectedTabColor: '#f2f2f2',
+                      tabColor: '#fff',
+                      tabTextColor: '#222',
+                  },
+                  status: {
+                      pipelineOnline: '#72B842',
+                      pipelineOnlineText: '#2E6707',
+                  },
               }
             : {
                   success: {
@@ -76,6 +85,15 @@ const createCustomTheme = (mode) => ({
                   },
                   cyan: {
                       main: 'rgba(101, 190, 255, 1)',
+                  },
+                  editor: {
+                      selectedTabColor: 'rgba(73, 123, 39, 0.31)',
+                      tabColor: '#222',
+                      tabTextColor: '#fff',
+                  },
+                  status: {
+                      pipelineOnline: '#72B842',
+                      pipelineOnlineText: '#72B842',
                   },
               }),
     },

--- a/frontend/src/utils/drawerStyles.js
+++ b/frontend/src/utils/drawerStyles.js
@@ -1,12 +1,12 @@
-const drawerWidth = 507;
+const drawerWidth = 720;
 
-const drawerStyles = (theme) => {
+const customDrawerStyles = (theme) => {
     return {
         width: drawerWidth,
         flexShrink: 0,
         zIndex: 9998,
-        [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box', background: theme.palette.sidebar.main },
+        [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box' },
     };
 };
 
-export default drawerStyles;
+export default customDrawerStyles;


### PR DESCRIPTION
Fixed the design based on the wireframes and added a new component for the dropdown menu.

![pipelinePage](https://user-images.githubusercontent.com/44384526/150640159-16f8f8d3-8e55-43a5-91d6-19523e4539a8.jpg)

I used another library for the react part of monaco editor, i used [monaco-react](https://github.com/suren-atoyan/monaco-react) instead of [react-monaco-editor](https://github.com/react-monaco-editor/react-monaco-editor), simply because [monaco-react](https://github.com/suren-atoyan/monaco-react) allow us to use the monaco editor without needing to use webpack (or rollup/parcel/etc) configuration files / plugins. Let me know if this is an issue, if it is i'll change it back to the library we originally discussed.

![codeDrawer](https://user-images.githubusercontent.com/44384526/150640199-3b5254de-169e-4e49-8f3c-af2b88b32806.jpg)

