### PR TITLE
Worker details global filter bug fixed

### DIFF
--- a/frontend/src/pages/Workers/WorkerDetail.jsx
+++ b/frontend/src/pages/Workers/WorkerDetail.jsx
@@ -77,6 +77,7 @@ export default function WorkerDetail() {
         {
             columns,
             data,
+            autoResetGlobalFilter: false,
         },
         useGlobalFilter
     );


### PR DESCRIPTION
Fixed global filter bug in this page.
Global filter value used to reset to undefined on each render(every second). Now is it fixed.

![image](https://user-images.githubusercontent.com/53895969/153053642-83c886a9-2583-4c10-8059-2bba7ce37e8a.png)
