### PR TITLE
Pipeline permission page - Changed icon size and alignment

### DIFF
--- a/frontend/src/pages/PipelinesPermission.jsx
+++ b/frontend/src/pages/PipelinesPermission.jsx
@@ -252,7 +252,8 @@ const CustomAccess = ({ row, onClick }) => {
                     <Box
                         component={FontAwesomeIcon}
                         sx={{
-                            fontSize: '0.6875rem',
+                            flex: 0.2,
+                            fontSize: 14,
                             fontWeight: 900,
                             paddingY: '2px',
                             mr: '10px',
@@ -260,7 +261,7 @@ const CustomAccess = ({ row, onClick }) => {
                         }}
                         icon={access.includes(accessDictionary[option]) ? faCheck : faTimes}
                     />
-                    <Typography variant="subtitle1" lineHeight="16px" ml={1}>
+                    <Typography flex={4} variant="subtitle1" lineHeight="16px">
                         {prettyAccess(option)}
                     </Typography>
                 </Box>


### PR DESCRIPTION
1. Changed pipeline permissions page icon size and alignment

![icons](https://user-images.githubusercontent.com/44384526/158870943-6c3c2b6e-9a74-46a1-ac9f-e42235abb7e1.jpg)