### PR TITLE
Add support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,20 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: 
-      interval: daily
+      interval: monthly
   - package-ecosystem: "docker"
     directory: "/docker-build"
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/cypress"
     schedule:
-      interval: "daily"
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: daily
+  - package-ecosystem: "docker"
+    directory: "/docker-build"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/cypress"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I found dataplane while looking at projects based on https://github.com/gofiber/fiber the first thing I noticed is that it's several minor versions behind the current latest release of Fiber.

Added:
- Track dependency updates for Go, Docker, NPM, and Github Actions

Dependabot will automatically create a PR for each dependency that needs to be updated.

