### PR TITLE
Code editor improvements

### DIFF
--- a/frontend/src/components/EditorPage/EditorColumn/index.jsx
+++ b/frontend/src/components/EditorPage/EditorColumn/index.jsx
@@ -444,6 +444,7 @@ const EditorColumn = forwardRef(({ children, ...rest }, ref) => {
                                 options={{
                                     minimap: { enabled: false },
                                     hideCursorInOverviewRuler: { enabled: true },
+                                    automaticLayout: { enabled: true },
                                 }}
                             />
                         ) : null}

--- a/frontend/src/components/EditorPage/FileManager/index.jsx
+++ b/frontend/src/components/EditorPage/FileManager/index.jsx
@@ -516,7 +516,7 @@ const FileManagerColumn = forwardRef(({ children, ...rest }, ref) => {
                                     </IconButton>
                                 </Tooltip>
                             ) : null}
-                            <Tooltip title="Delete" id="hi" placement="bottom" PopperProps={{ sx: { '& .MuiTooltip-tooltipPlacementBottom': { marginTop: '0px !important' } } }}>
+                            <Tooltip title="Delete" placement="bottom" PopperProps={{ sx: { '& .MuiTooltip-tooltipPlacementBottom': { marginTop: '0px !important' } } }}>
                                 <IconButton sx={{ pointerEvents: 'all' }} aria-label="Delete" onClick={handleDeleteIconClick}>
                                     <Box component={FontAwesomeIcon} icon={faTimes} sx={{ color: 'editorPage.fileManagerIcon', fontSize: '0.75rem' }} />
                                 </IconButton>

--- a/frontend/src/components/EditorPage/Markdown/index.jsx
+++ b/frontend/src/components/EditorPage/Markdown/index.jsx
@@ -100,7 +100,7 @@ export function MarkdownContent({ bottomPadding = false, sx }) {
                                         showLineNumbers={true}
                                         children={String(children).replace(/\n$/, '')}
                                         language={match[1]}
-                                        // {...props}
+                                        {...props}
                                     />
                                     <div
                                         style={{

--- a/frontend/src/components/EditorPage/Markdown/index.jsx
+++ b/frontend/src/components/EditorPage/Markdown/index.jsx
@@ -90,13 +90,13 @@ export function MarkdownContent({ bottomPadding = false, sx }) {
                                 <Box
                                     position="relative"
                                     onMouseOver={() => setHover(true)}
+                                    fontSize="1rem"
                                     onMouseLeave={() => {
                                         setCopyActive(false);
                                         setHover(false);
                                     }}>
                                     <SyntaxHighlighter
                                         copyToClipboard={true}
-                                        id="hii"
                                         showLineNumbers={true}
                                         children={String(children).replace(/\n$/, '')}
                                         language={match[1]}

--- a/frontend/src/components/EditorPage/Markdown/index.jsx
+++ b/frontend/src/components/EditorPage/Markdown/index.jsx
@@ -60,6 +60,12 @@ export function MarkdownContent({ bottomPadding = false, sx }) {
             opacity: 1,
             background: 'transparent',
         },
+        '&:hover > span > svg:nth-of-type(2)': {
+            opacity: props.active ? 1 : 0,
+        },
+        '&:hover > span > svg:first-of-type': {
+            opacity: props.active ? 0 : 1,
+        },
     }));
 
     return (
@@ -90,10 +96,11 @@ export function MarkdownContent({ bottomPadding = false, sx }) {
                                     }}>
                                     <SyntaxHighlighter
                                         copyToClipboard={true}
+                                        id="hii"
                                         showLineNumbers={true}
                                         children={String(children).replace(/\n$/, '')}
                                         language={match[1]}
-                                        {...props}
+                                        // {...props}
                                     />
                                     <div
                                         style={{
@@ -106,19 +113,17 @@ export function MarkdownContent({ bottomPadding = false, sx }) {
                                         <Button
                                             onClick={() => copy(String(children).replace(/\n$/, ''))}
                                             hover={hover}
+                                            active={copyActive}
                                             type="button"
                                             aria-label="Copy code to clipboard"
                                             title="Copy">
                                             <ButtonSVGs aria-hidden="true">
-                                                {copyActive ? (
-                                                    <SVGClass2 viewBox="0 0 24 24">
-                                                        <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path>
-                                                    </SVGClass2>
-                                                ) : (
-                                                    <SVGClass1 viewBox="0 0 24 24">
-                                                        <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"></path>
-                                                    </SVGClass1>
-                                                )}
+                                                <SVGClass1 viewBox="0 0 24 24">
+                                                    <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"></path>
+                                                </SVGClass1>
+                                                <SVGClass2 active={copyActive} viewBox="0 0 24 24">
+                                                    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path>
+                                                </SVGClass2>
                                             </ButtonSVGs>
                                         </Button>
                                     </div>
@@ -158,7 +163,7 @@ const SVGClass1 = styled.svg({
 const SVGClass2 = styled.svg({
     fill: 'green',
     left: ' 50%',
-    opacity: 1,
+    opacity: 0,
     top: '50%',
     transform: 'scale(1)',
     transitionDelay: '75ms',


### PR DESCRIPTION
- Clicking on copy button now only displays the check mark for respective code block.
- Monaco editor now has responsive width. Scrollbar out of place bug fixed.
- Code block text matches rest of markdown text

![image](https://user-images.githubusercontent.com/53895969/203533828-ce64382e-30fc-4cb7-bfd7-e2f588d10c1d.png)

